### PR TITLE
Add check for RejectItem_(O)460

### DIFF
--- a/NPCPatches.cs
+++ b/NPCPatches.cs
@@ -1006,6 +1006,11 @@ namespace PolyamorySweetLove
                         who.changeFriendship(-100, __instance);
                         return false;
                     }
+                    else if (__instance.TryGetDialogue("RejectItem_(O)460") != null)
+                    {
+                        Monitor.Log($"Tried to give pendant to someone with dialogue key RejectItem_(O)460");
+                        return true;
+                    }
                     else
                     {
 


### PR DESCRIPTION
Here's a little contribution to prevent a marriage in the case someone uses one of the new 1.6 features. There are two mods that I know of which currently use the RejectItem_(O)460 dialogue key for special cases regarding marriage:
- Rodney from Creative Differences (https://www.nexusmods.com/stardewvalley/mods/13437) uses RejectItem_(O)460 to prevent a marriage if the pendant is given (he should only be dateable, but not marriageable)
- Mateo and Hector (and Cirrus in the future) from Never Ending Adventure and Circle of Thorns/Sword of Sorcery (https://www.nexusmods.com/stardewvalley/mods/12369) use RejectItem_(O)460 to have a dating period and after this period is expired to start an engagement event through SpaceCore if the pendant is given